### PR TITLE
Sanitized

### DIFF
--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -441,7 +441,7 @@ struct Dict[K: KeyElement, V: CollectionElement](
 
     @always_inline
     fn __init__(inout self):
-        """Initialize an empty dictiontary."""
+        """Initialize an empty dictionary."""
         self.size = 0
         self._n_entries = 0
         self._reserved = Self._initial_reservation
@@ -450,7 +450,7 @@ struct Dict[K: KeyElement, V: CollectionElement](
 
     @always_inline
     fn __init__(inout self, existing: Self):
-        """Copy an existing dictiontary.
+        """Copy an existing dictionary.
 
         Args:
             existing: The existing dict.

--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -496,7 +496,7 @@ struct Dict[K: KeyElement, V: CollectionElement](
         return dict
 
     fn __copyinit__(inout self, existing: Self):
-        """Copy an existing dictiontary.
+        """Copy an existing dictionary.
 
         Args:
             existing: The existing dict.
@@ -508,7 +508,7 @@ struct Dict[K: KeyElement, V: CollectionElement](
         self._entries = existing._entries
 
     fn __moveinit__(inout self, owned existing: Self):
-        """Move data of an existing dict into a new one.
+        """Move data of an existing dictionary into a new one.
 
         Args:
             existing: The existing dict.

--- a/stdlib/src/collections/vector.mojo
+++ b/stdlib/src/collections/vector.mojo
@@ -64,7 +64,7 @@ fn _calculate_fixed_vector_default_size[type: AnyTrivialRegType]() -> Int:
     alias prefered_inline_bytes = prefered_bytecount - sizeof[
         InlinedFixedVector[type, 0]
     ]()
-    alias num_elements = prefered_inline_bytes // sizeof_type
+    alias num_elements = preferred_inline_bytes // sizeof_type
     return num_elements or 1
 
 

--- a/stdlib/src/collections/vector.mojo
+++ b/stdlib/src/collections/vector.mojo
@@ -54,14 +54,14 @@ struct _VecIter[
 
 @always_inline
 fn _calculate_fixed_vector_default_size[type: AnyTrivialRegType]() -> Int:
-    alias prefered_bytecount = 64
+    alias preferred_bytecount = 64
     alias sizeof_type = sizeof[type]()
 
     @parameter
     if sizeof_type >= 256:
         return 0
 
-    alias prefered_inline_bytes = prefered_bytecount - sizeof[
+    alias preferred_inline_bytes = preferred_bytecount - sizeof[
         InlinedFixedVector[type, 0]
     ]()
     alias num_elements = preferred_inline_bytes // sizeof_type

--- a/stdlib/src/memory/reference.mojo
+++ b/stdlib/src/memory/reference.mojo
@@ -67,7 +67,7 @@ struct _GPUAddressSpace(EqualityComparable):
 
     @always_inline("nodebug")
     fn __eq__(self, other: Self) -> Bool:
-        """The True if the two address spaces are equal and False otherwise.
+        """True if the two address spaces are equal and False otherwise.
 
         Returns:
           True if the two address spaces are equal and False otherwise.
@@ -76,7 +76,7 @@ struct _GPUAddressSpace(EqualityComparable):
 
     @always_inline("nodebug")
     fn __eq__(self, other: AddressSpace) -> Bool:
-        """The True if the two address spaces are equal and False otherwise.
+        """True if the two address spaces are equal and False otherwise.
 
         Returns:
           True if the two address spaces are equal and False otherwise.

--- a/stdlib/src/memory/unsafe_pointer.mojo
+++ b/stdlib/src/memory/unsafe_pointer.mojo
@@ -405,7 +405,7 @@ fn destroy_pointee(ptr: UnsafePointer[_]):
     The pointer must not be null, and the pointer memory location is assumed
     to contain a valid initialized instance of `T`.  This is equivalent to
     `_ = move_from_pointee(ptr)` but doesn't require `Movable` and is more
-    efficient becase it doesn't invoke `__moveinit__`.
+    efficient because it doesn't invoke `__moveinit__`.
 
     Args:
         ptr: The pointer whose pointee this destroys.
@@ -491,7 +491,7 @@ fn move_pointee[T: Movable](*, src: UnsafePointer[T], dst: UnsafePointer[T]):
     pointer are not valid unless and until a new, valid value has been
     moved into this pointer's memory location using `initialize_pointee_move()`.
 
-    This transfers the value out of `self` and into `dest` using at most one
+    This transfers the value out of `src` and into `dst` using at most one
     `__moveinit__()` call.
 
     Safety:

--- a/stdlib/src/os/atomic.mojo
+++ b/stdlib/src/os/atomic.mojo
@@ -164,7 +164,7 @@ struct Atomic[type: DType]:
     ) -> Bool:
         """Atomically compares the self value with that of the expected value.
         If the values are equal, then the self value is replaced with the
-        desired value and True is returned. Otherwise, False is returned the
+        desired value and True is returned. Otherwise, False is returned and
         the expected value is rewritten with the self value.
 
         Args:
@@ -231,7 +231,7 @@ struct Atomic[type: DType]:
         """Performs atomic in-place max.
 
         Atomically replaces the current value with the result of max of the
-        value and arg. The operation is a read-modify-write operation perform
+        value and arg. The operation is a read-modify-write operation performed
         according to sequential consistency semantics.
 
         Constraints:
@@ -258,9 +258,8 @@ struct Atomic[type: DType]:
         """Performs atomic in-place min.
 
         Atomically replaces the current value with the result of min of the
-        value and arg. The operation is a read-modify-write operation. The
-        operation is a read-modify-write operation perform according to
-        sequential consistency semantics.
+        value and arg. The operation is a read-modify-write operation performed
+        according to sequential consistency semantics.
 
         Constraints:
             The input type must be either integral or floating-point type.

--- a/stdlib/src/os/fstat.mojo
+++ b/stdlib/src/os/fstat.mojo
@@ -47,7 +47,7 @@ fn _constrain_unix():
 
 @value
 struct stat_result(Stringable):
-    """Object whose fields correspond  to the members of the stat structure."""
+    """Object whose fields correspond to the members of the stat structure."""
 
     var st_mode: Int
     """File mode: file type and file mode bits (permissions)."""
@@ -210,7 +210,7 @@ fn stat[pathlike: os.PathLike](path: pathlike) raises -> stat_result:
     """Get the status of a file or a file descriptor.
 
     Parameters:
-      pathlike: The a type conforming to the os.PathLike trait.
+      pathlike: A type conforming to the os.PathLike trait.
 
     Args:
       path: The path to the directory.

--- a/stdlib/src/sys/_assembly.mojo
+++ b/stdlib/src/sys/_assembly.mojo
@@ -612,7 +612,7 @@ fn inlined_assembly[
                 assembly = asm.value,
                 constraints = constraints.value,
                 hasSideEffects = __mlir_attr.unit,
-            ](arg0, arg1, arg2, arg3, arg3, arg5, arg6, arg7, arg8)
+            ](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
         else:
             return __mlir_op.`pop.inline_asm`[
                 _type=result_type,

--- a/stdlib/src/utils/inline_string.mojo
+++ b/stdlib/src/utils/inline_string.mojo
@@ -59,7 +59,7 @@ struct InlineString(Sized, Stringable, CollectionElement):
         self._storage = Self.Layout(fixed^)
 
     fn __init__(inout self, literal: StringLiteral):
-        """Constructs a InlineString value given a string literal.
+        """Constructs an InlineString value given a string literal.
 
         Args:
             literal: The input constant string.
@@ -304,7 +304,7 @@ struct _FixedString[CAP: Int](
     var buffer: InlineArray[UInt8, CAP]
     """The underlying storage for the fixed string."""
     var size: Int
-    """The number of elements in the vector."""
+    """The number of elements in the buffer."""
 
     # ===------------------------------------------------------------------===#
     # Life cycle methods

--- a/stdlib/src/utils/inline_string.mojo
+++ b/stdlib/src/utils/inline_string.mojo
@@ -294,7 +294,7 @@ struct _FixedString[CAP: Int](
 ):
     """A string with a fixed available capacity.
 
-    The string data is stored inline in this structs memory layout.
+    The string data is stored inline in this struct's memory layout.
 
     Parameters:
         CAP: The fixed-size count of bytes of string storage capacity available.

--- a/stdlib/src/utils/loop.mojo
+++ b/stdlib/src/utils/loop.mojo
@@ -109,7 +109,7 @@ fn unroll[
           arguments: one for each nested loop index value.
         dim0: The first dimension size.
         dim1: The second dimension size.
-        dim2: The second dimension size.
+        dim2: The third dimension size.
     """
 
     @parameter

--- a/stdlib/src/utils/numerics.mojo
+++ b/stdlib/src/utils/numerics.mojo
@@ -347,7 +347,7 @@ struct FPUtils[
 
 
 struct FlushDenormals:
-    """Flushes and denormals are set to zero within the context and the state
+    """Flushes denormals to zero within the context and the state
     is restored to the prior value on exit."""
 
     var state: Int32
@@ -929,7 +929,7 @@ fn ulp[
     the number.
 
     Constraints:
-        The element type of the inpiut must be a floating-point type.
+        The element type of the input must be a floating-point type.
 
     Parameters:
         type: The `dtype` of the input and output SIMD vector.

--- a/stdlib/test/bit/test_bit.mojo
+++ b/stdlib/test/bit/test_bit.mojo
@@ -280,7 +280,7 @@ def test_is_power_of_two_simd():
 def test_bit_width():
     assert_equal(bit_width(-(2**59)), 59)
     assert_equal(bit_width(-2), 1)
-    assert_equal(bit_width(-1), 0)
+    assert_equal(bit_width(-1), 1)
     assert_equal(bit_width(0), 0)
     assert_equal(bit_width(1), 1)
     assert_equal(bit_width(2), 2)

--- a/stdlib/test/builtin/test_file.mojo
+++ b/stdlib/test/builtin/test_file.mojo
@@ -182,7 +182,7 @@ struct Word:
     var second_letter: UInt8
     var third_letter: UInt8
     var fourth_letter: UInt8
-    var fith_letter: UInt8
+    var fifth_letter: UInt8
 
     fn __str__(self) -> String:
         var word = List[UInt8](capacity=6)
@@ -214,9 +214,9 @@ def test_file_read_to_dtype_pointer():
 def test_file_get_raw_fd():
     # since JIT and build give different file descriptors, we test by checking
     # if we printed to the right file.
-    var f1 = open(Path(TEMP_FILE_DIR) / "test_file_dummy_1", "rw")
-    var f2 = open(Path(TEMP_FILE_DIR) / "test_file_dummy_2", "rw")
-    var f3 = open(Path(TEMP_FILE_DIR) / "test_file_dummy_2", "rw")
+    var f1 = open(Path(TEMP_FILE_DIR) / "test_file_dummy_1", "r+")
+    var f2 = open(Path(TEMP_FILE_DIR) / "test_file_dummy_2", "r+")
+    var f3 = open(Path(TEMP_FILE_DIR) / "test_file_dummy_3", "r+")
 
     print(
         "test from file 1",

--- a/stdlib/test/builtin/test_hash.mojo
+++ b/stdlib/test/builtin/test_hash.mojo
@@ -56,7 +56,7 @@ def test_hash_byte_array():
     )
 
     # This test is just really bad. We really need to re-evaluate the
-    # right way to test these. Hash function behavior varies a bit  based
+    # right way to test these. Hash function behavior varies a bit based
     # on architecture, so these tests as-is end up being really flaky.
     # Making this _much_ more relaxed for now, but at least still testing
     # that at least the hash function returns _some_ different things.

--- a/stdlib/test/builtin/test_hasher.mojo
+++ b/stdlib/test/builtin/test_hasher.mojo
@@ -60,7 +60,7 @@ def test_hash_with_hasher():
 
 
 @value
-struct ComplexeHashableStruct(_HashableWithHasher):
+struct ComplexHashableStruct(_HashableWithHasher):
     var _value1: SomeHashableStruct
     var _value2: SomeHashableStruct
 
@@ -78,7 +78,7 @@ def test_complex_hasher():
     assert_equal(hasher^.finish(), 52)
 
 
-def test_complexe_hash_with_hasher():
+def test_complex_hash_with_hasher():
     var hashable = ComplexeHashableStruct(
         SomeHashableStruct(42), SomeHashableStruct(10)
     )
@@ -116,5 +116,5 @@ def main():
     test_hasher()
     test_hash_with_hasher()
     test_complex_hasher()
-    test_complexe_hash_with_hasher()
+    test_complex_hash_with_hasher()
     test_update_with_bytes()

--- a/stdlib/test/builtin/test_hasher.mojo
+++ b/stdlib/test/builtin/test_hasher.mojo
@@ -71,7 +71,7 @@ struct ComplexHashableStruct(_HashableWithHasher):
 
 def test_complex_hasher():
     var hasher = DummyHasher()
-    var hashable = ComplexeHashableStruct(
+    var hashable = ComplexHashableStruct(
         SomeHashableStruct(42), SomeHashableStruct(10)
     )
     hasher.update(hashable)
@@ -79,7 +79,7 @@ def test_complex_hasher():
 
 
 def test_complex_hash_with_hasher():
-    var hashable = ComplexeHashableStruct(
+    var hashable = ComplexHashableStruct(
         SomeHashableStruct(42), SomeHashableStruct(10)
     )
     assert_equal(_hash_with_hasher[DummyHasher](hashable), 52)

--- a/stdlib/test/builtin/test_slice.mojo
+++ b/stdlib/test/builtin/test_slice.mojo
@@ -22,7 +22,7 @@ def test_none_end_folds():
     assert_equal(all_def_slice.step, 1)
 
 
-# This requires parameter inference of StartT.
+# This requires parameter inference of Start.
 @value
 struct FunnySlice:
     var start: Int

--- a/stdlib/test/builtin/test_sort.mojo
+++ b/stdlib/test/builtin/test_sort.mojo
@@ -569,7 +569,7 @@ struct Person(ComparableCollectionElement):
         return self.age != other.age or self.name != other.name
 
 
-def test_sort_comparamble_elements_list():
+def test_sort_comparable_elements_list():
     var list = List[Person]()
 
     @parameter
@@ -594,7 +594,7 @@ def test_sort_comparamble_elements_list():
     assert_sorted(list)
 
 
-fn test_sort_empty_comparamble_elements_list() raises:
+fn test_sort_empty_comparable_elements_list() raises:
     var person_list = List[Person]()
     sort(person_list)
     insertion_sort(person_list)
@@ -629,5 +629,5 @@ def main():
     test_sort_string_small_list()
     test_sort_string_big_list()
     test_sort_strings()
-    test_sort_comparamble_elements_list()
-    test_sort_empty_comparamble_elements_list()
+    test_sort_comparable_elements_list()
+    test_sort_empty_comparable_elements_list()

--- a/stdlib/test/builtin/test_string_literal.mojo
+++ b/stdlib/test/builtin/test_string_literal.mojo
@@ -68,7 +68,7 @@ def test_rfind():
     assert_equal("".rfind("ab"), -1)
     assert_equal("foo".rfind(""), 3)
 
-    # Test that rfind(start) returned pos is absolute, not relative to specifed
+    # Test that rfind(start) returned pos is absolute, not relative to specified
     # start. Also tests positive and negative start offsets.
     assert_equal("hello world".rfind("l", 5), 9)
     assert_equal("hello world".rfind("l", -5), 9)

--- a/stdlib/test/memory/test_memory.mojo
+++ b/stdlib/test/memory/test_memory.mojo
@@ -190,13 +190,13 @@ def test_memcmp_extensive[
         dptr1[i] = i
 
         @parameter
-        if extermes == "":
+        if extremes == "":
             ptr2[i] = i + 1
             dptr2[i] = i + 1
-        elif extermes == "nan":
+        elif extremes == "nan":
             ptr2[i] = nan[type]()
             dptr2[i] = nan[type]()
-        elif extermes == "inf":
+        elif extremes == "inf":
             ptr2[i] = Scalar[type].MAX
             dptr2[i] = Scalar[type].MAX
 

--- a/stdlib/test/memory/test_memory.mojo
+++ b/stdlib/test/memory/test_memory.mojo
@@ -173,11 +173,11 @@ def test_memcmp_simd():
     assert_equal(c, 1, "[..., 0, 120, 100] is bigger than [..., 0, 120, 90]")
 
     c = memcmp(p2, p1, length)
-    assert_equal(c, -1, "[..., 0, 120, 90] is smaller than [..., 120, 100]")
+    assert_equal(c, -1, "[..., 0, 120, 90] is smaller than [..., 0, 120, 100]")
 
 
 def test_memcmp_extensive[
-    type: DType, extermes: StringLiteral = ""
+    type: DType, extremes: StringLiteral = ""
 ](count: Int):
     var ptr1 = Pointer[Scalar[type]].alloc(count)
     var ptr2 = Pointer[Scalar[type]].alloc(count)
@@ -222,7 +222,7 @@ def test_memcmp_extensive[
         "for dtype="
         + str(type)
         + ";extremes="
-        + str(extermes)
+        + str(extremes)
         + ";count="
         + str(count),
     )
@@ -232,7 +232,7 @@ def test_memcmp_extensive[
         "for dtype="
         + str(type)
         + ";extremes="
-        + str(extermes)
+        + str(extremes)
         + ";count="
         + str(count),
     )
@@ -242,7 +242,7 @@ def test_memcmp_extensive[
         "for dtype="
         + str(type)
         + ";extremes="
-        + str(extermes)
+        + str(extremes)
         + ";count="
         + str(count),
     )

--- a/stdlib/test/os/path/test_isdir.mojo
+++ b/stdlib/test/os/path/test_isdir.mojo
@@ -22,5 +22,5 @@ from testing import assert_true, assert_false
 def main():
     assert_true(isdir(Path()))
     assert_true(isdir(str(cwd())))
-    assert_false(isdir(str(cwd() / "nonexistant")))
+    assert_false(isdir(str(cwd() / "nonexistent")))
     assert_false(isdir(__source_location().file_name))

--- a/stdlib/test/os/path/test_islink.mojo
+++ b/stdlib/test/os/path/test_islink.mojo
@@ -29,4 +29,4 @@ def main():
     assert_true(isdir(Path(TEMP_DIR)))
     assert_true(isdir(TEMP_DIR))
     assert_true(islink(TEMP_DIR))
-    assert_false(islink(str(Path(TEMP_DIR) / "nonexistant")))
+    assert_false(islink(str(Path(TEMP_DIR) / "nonexistent")))

--- a/stdlib/test/os/test_remove.mojo
+++ b/stdlib/test/os/test_remove.mojo
@@ -59,7 +59,7 @@ fn test_remove() raises:
         "Unexpected file " + my_file_name + " it should not exist",
     )
 
-    # tyring to delete non existing file
+    # trying to delete non existing file
     with assert_raises(contains="Can not remove file: "):
         remove(my_file_name)
     with assert_raises(contains="Can not remove file: "):

--- a/stdlib/test/sys/test_dlhandle.mojo
+++ b/stdlib/test/sys/test_dlhandle.mojo
@@ -18,7 +18,7 @@ from testing import assert_false
 
 def check_invalid_dlhandle():
     assert_false(
-        DLHandle("/an/invalid/library"), "the library is not valid location"
+        DLHandle("/an/invalid/library"), "the library is not a valid location"
     )
 
 

--- a/stdlib/test/test_utils/types.mojo
+++ b/stdlib/test/test_utils/types.mojo
@@ -34,7 +34,7 @@ struct MoveOnly[T: Movable](Movable):
         """Move construct a MoveOnly from an existing variable.
 
         Args:
-            other: The other instance that we copying the payload from.
+            other: The other instance that we are copying the payload from.
         """
         self.data = other.data^
 

--- a/stdlib/test/testing/test_assertion.mojo
+++ b/stdlib/test/testing/test_assertion.mojo
@@ -141,7 +141,7 @@ def test_assert_almost_equal():
 
     _should_fail[DType.bool, 1](True, False)
     _should_fail(
-        SIMD[DType.int32, 2](0, 1), SIMD[DType.int32, 2](0, -1), atol=5.0
+        SIMD[DType.int32, 2](0, 1), SIMD[DType.int32, 2](0, -1), atol=5
     )
     _should_fail(
         SIMD[float_type, 2](-_inf, 0.0),


### PR DESCRIPTION
- **bugfix**
- **fix: correct typos in vector.mojo**
- **fix: Correct typos in dictionary comments**
- **fix: Fix typos and copy-paste mistakes in fstat.mojo**
- **fix: Fix typos and copy-paste mistakes in atomic.mojo**
- **fix: Correct duplicate argument in inlined_assembly function**
- **fix: Correct typo in docstring of `_FixedString` struct**
- **fix: correct typos and copy-paste mistakes in inline_string.mojo**
- **fix: Correct typos and copy-paste mistakes in numerics.mojo**
- **fix: correct typo in loop.mojo docstring**
- **fix: Remove unnecessary "The" from docstrings**
- **fix: Fix typos and copy-paste mistakes**
- **fix: Correct typos and copy-paste mistakes in file**
- **fix: remove extra space in comment**
- **fix: Correct typo in comment**
- **fix: Correct typos and copy-paste mistakes in test_hasher.mojo**
- **fix: Correct typos and copy-paste mistakes in test_sort.mojo**
- **fix: Correct typo in comment**
- **fix: Correct typos and copy-paste mistakes**
- **fix: Correct typo in test_isdir.mojo**
- **fix: Correct typo in test_islink.mojo**
- **fix: correct typo in error message**
- **fix: remove decimal point from atol parameter**
- **fix: correct typo in docstring**
- **fix: Correct typos and copy-paste mistakes in memory test**
- **fix: Correct bit width for -1**
- **docs: fix typos in documentation**
